### PR TITLE
Added NameOnly grouping

### DIFF
--- a/Assets/Plugins/ScriptableObjectDropdown/Editor/ScriptableObjectDropdownDrawer.cs
+++ b/Assets/Plugins/ScriptableObjectDropdown/Editor/ScriptableObjectDropdownDrawer.cs
@@ -285,6 +285,9 @@ namespace ScriptableObjectDropdown.Editor
                     path = path.Replace("/", " > ");
                     return path;
 
+                case ScriptableObjectGrouping.NameOnly:
+                    return scriptableObject.name;
+
                 case ScriptableObjectGrouping.ByFolder:
                     return path;
 

--- a/Assets/Plugins/ScriptableObjectDropdown/ScriptableObjectDropdownAttribute.cs
+++ b/Assets/Plugins/ScriptableObjectDropdown/ScriptableObjectDropdownAttribute.cs
@@ -16,6 +16,10 @@ namespace ScriptableObjectDropdown
         /// </summary>
         None,
         /// <summary>
+        /// No grouping, only the base name of the ScriptableObject; for instance "SpecialScriptableObject"
+        /// </summary>
+        NameOnly,
+        /// <summary>
         /// Group classes by namespace and show foldout menus for nested namespaces; for
         /// instance, "MainFolder >> NestedFolder >> SpecialScriptableObject".
         /// </summary>


### PR DESCRIPTION
Allows users to see only the name of the different ScriptableObjects, without a path hierarchy